### PR TITLE
Fix tokenizer bug

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/pipelines.py
+++ b/runtimes/huggingface/mlserver_huggingface/pipelines.py
@@ -2,6 +2,7 @@ from typing import Union, List
 
 from transformers import Pipeline
 from transformers import AutoModel
+from transformers import AutoTokenizer
 from sentence_transformers.util import is_sentence_transformer_model
 from sentence_transformers import SentenceTransformer
 
@@ -9,7 +10,10 @@ from sentence_transformers import SentenceTransformer
 class StEmbeddingPipeline(Pipeline):
     """A custom huggingface pipeline that wraps sentence transformers embedder"""
 
-    def __init__(self, model: AutoModel, **kwargs):
+    def __init__(self, model: AutoModel,tokenizer:AutoTokenizer, **kwargs):
+        # This tokenzier is not being used
+        # sentence-transformers model contains a tokenizer 
+        self.tokenizer = tokenizer
         (
             self._preprocess_params,
             self._forward_params,

--- a/runtimes/huggingface/mlserver_huggingface/pipelines.py
+++ b/runtimes/huggingface/mlserver_huggingface/pipelines.py
@@ -11,7 +11,7 @@ class StEmbeddingPipeline(Pipeline):
     """A custom huggingface pipeline that wraps sentence transformers embedder"""
 
     def __init__(self, model: AutoModel, tokenizer: AutoTokenizer, **kwargs):
-        #self.tokenzier is not being used.sentence-transformers model has a tokenizer
+        # self.tokenzier is not being used.sentence-transformers model has a tokenizer
         self.tokenizer = tokenizer
         (
             self._preprocess_params,

--- a/runtimes/huggingface/mlserver_huggingface/pipelines.py
+++ b/runtimes/huggingface/mlserver_huggingface/pipelines.py
@@ -11,8 +11,7 @@ class StEmbeddingPipeline(Pipeline):
     """A custom huggingface pipeline that wraps sentence transformers embedder"""
 
     def __init__(self, model: AutoModel, tokenizer: AutoTokenizer, **kwargs):
-        # This tokenzier is not being used
-        # sentence-transformers model contains a tokenizer 
+        # This tokenzier is not being used.sentence-transformers model contains a tokenizer
         self.tokenizer = tokenizer
         (
             self._preprocess_params,
@@ -24,7 +23,7 @@ class StEmbeddingPipeline(Pipeline):
             self.model_name
         ), f"{self.model_name} is not a sentence transformers model."
         self.model = SentenceTransformer(self.model_name)
-        
+
     def _sanitize_parameters(self, **kwargs):
         forward_kwargs = {}
         if "prompt_name" in kwargs:

--- a/runtimes/huggingface/mlserver_huggingface/pipelines.py
+++ b/runtimes/huggingface/mlserver_huggingface/pipelines.py
@@ -10,7 +10,7 @@ from sentence_transformers import SentenceTransformer
 class StEmbeddingPipeline(Pipeline):
     """A custom huggingface pipeline that wraps sentence transformers embedder"""
 
-    def __init__(self, model: AutoModel,tokenizer:AutoTokenizer, **kwargs):
+    def __init__(self, model: AutoModel, tokenizer: AutoTokenizer, **kwargs):
         # This tokenzier is not being used
         # sentence-transformers model contains a tokenizer 
         self.tokenizer = tokenizer
@@ -24,6 +24,7 @@ class StEmbeddingPipeline(Pipeline):
             self.model_name
         ), f"{self.model_name} is not a sentence transformers model."
         self.model = SentenceTransformer(self.model_name)
+        
     def _sanitize_parameters(self, **kwargs):
         forward_kwargs = {}
         if "prompt_name" in kwargs:

--- a/runtimes/huggingface/mlserver_huggingface/pipelines.py
+++ b/runtimes/huggingface/mlserver_huggingface/pipelines.py
@@ -24,7 +24,6 @@ class StEmbeddingPipeline(Pipeline):
             self.model_name
         ), f"{self.model_name} is not a sentence transformers model."
         self.model = SentenceTransformer(self.model_name)
-
     def _sanitize_parameters(self, **kwargs):
         forward_kwargs = {}
         if "prompt_name" in kwargs:

--- a/runtimes/huggingface/mlserver_huggingface/pipelines.py
+++ b/runtimes/huggingface/mlserver_huggingface/pipelines.py
@@ -11,7 +11,7 @@ class StEmbeddingPipeline(Pipeline):
     """A custom huggingface pipeline that wraps sentence transformers embedder"""
 
     def __init__(self, model: AutoModel, tokenizer: AutoTokenizer, **kwargs):
-        # This tokenzier is not being used.sentence-transformers model contains a tokenizer
+        #self.tokenzier is not being used.sentence-transformers model has a tokenizer
         self.tokenizer = tokenizer
         (
             self._preprocess_params,


### PR DESCRIPTION
It looks like pipeline is required to have a tokenizer property.
I added a tokenizer property, even though it's not being used for anything.
Notes that sentence-transformers model has their own tokenizer under property model.


in `mlserver-huggingface.common.py::load_pipeline_from_setting` function
```python
    # If max_batch_size > 1 we need to ensure tokens are padded
    if settings.max_batch_size > 1:
        model = hf_pipeline.model
        if not hf_pipeline.tokenizer.pad_token_id:
            eos_token_id = model.config.eos_token_id  # type: ignore
            if eos_token_id:
                hf_pipeline.tokenizer.pad_token_id = [str(eos_token_id)]  # type: ignore
            else:
                logger.warning(
                    "Model has neither pad_token or eos_token, setting batch size to 1"
                )
                hf_pipeline._batch_size = 1

```

We are doing some modification to `tokenizer `when `max_batch_size` is greater than 1.
It also seems that inference server would deliberately set `max_batch_size`  to be greater than 1
Sentence-transformer model has their own way to handle `max_batch_size`.
To avoid bug, we keep a tokenizer property in `StEmbeddingPipeline`